### PR TITLE
Update OWASP backronym: Web -> Worldwide

### DIFF
--- a/index.md
+++ b/index.md
@@ -22,7 +22,7 @@ Semua sektor yang ingin berkontribusi dan menjadi sponsor sangat kami persilahka
 [![OWASP 20th Anniversary Image](assets/images/owasp-20th-anniversary.jpeg)](https://20thanniversary.owasp.org/)
 
 ## Participation
-The Open Web Application Security Project (OWASP) adalah lembaga Nirlaba yang bekerja untuk memperbaiki KEAMANAN PIRANTI LUNAK. Semua proyek, peralatan dokumen, pertemuan dan chapter adalah BEBAS dan TERBUKA untuk setiap orang yang tertarik mengembangkan KEAMANAN APLIKASI. 
+The Open Worldwide Application Security Project (OWASP) adalah lembaga Nirlaba yang bekerja untuk memperbaiki KEAMANAN PIRANTI LUNAK. Semua proyek, peralatan dokumen, pertemuan dan chapter adalah BEBAS dan TERBUKA untuk setiap orang yang tertarik mengembangkan KEAMANAN APLIKASI. 
 
 Chapters diarahkan oleh leaders lokal sesuai dengan [Chapters Policy](/www-policy/operational/chapters). Kontribusi Finansial hanya dilakukan secara daring menggunakan tombol donasi tepercaya. Untuk menjadi PEMBICARA/NARASUMBER pada setiap OWASP Chapter di seluruh dunia menggunakan review sederhana [speaker agreement](/www-policy/legal/speaker-agreement) dan kemudian menghubungi leader chapter lokal dengan menyampaikan secara detil apa yang akan disajikan Proyek OWASP yang dikerjakan, penelitian independen, atau terkait dengan topik KEAMANAN PIRANTI LUNAK.
 


### PR DESCRIPTION

This PR has been generated by [Arkadii Yakovets](https://nest.owasp.org/members/arkid15r) based on the OWASP Board of Directors February 2023 [motion](https://board.owasp.org/meetings-historical/2023/202302.15.html) to officially change the backronym OWASP (sponsored by [Mark Curphey](https://nest.owasp.org/members/curphey) and [Avi Douglen](https://nest.owasp.org/members/avidouglen)).

>Background: Motion: "Resolved that the Foundation will change **all current and future references** of the 'Open Web Application Security Project' to the 'Open Worldwide Application Security Project'".

The purpose of this PR is to update all references to OWASP to reflect the Board approved change of the organization's name from Open **Web** Application Security Project to Open **Worldwide** Application Security Project. This ensures consistency across documentation, metadata, and project materials in alignment with the Board's decision.

For any questions or clarifications you can reach out via:

- OWASP Slack: [Arkadii Yakovets](https://owasp.slack.com/team/U060W3NKLTF)
- LinkedIn: [in/arkid15r](https://www.linkedin.com/in/arkid15r)